### PR TITLE
🐛  Fix issue where unclosed html tags cause parsing error

### DIFF
--- a/events.md
+++ b/events.md
@@ -6,7 +6,7 @@ This page provides a guide to all the events supported by Adobe Sign.
 
 ## **System requirements**
 
-To use the event framework within Adobe Sign, you need a browser that supports `postMessage`. See  [this page](https://developer.mozilla.org/en-US/docs/Web/API/Window.postMessage) to get a list of all supported browsers.
+To use the event framework within Adobe Sign, you need a browser that supports `postMessage`. See [this page](https://developer.mozilla.org/en-US/docs/Web/API/Window.postMessage) to get a list of all supported browsers.
 
 ## **Supported events**
 
@@ -14,11 +14,11 @@ The following table lists the Adobe Sign supported UI events that can be embedde
 
 ### **Workflow events**
 
-| **Event Type** | **Data** | **Description** |
-| --- | --- | --- |
-| `ESIGN` | NONE | This event gets fired after a user has successfully signed an agreement. |
-| `REJECT` | NONE | This event is fired after a user rejects an agreement. |
-| `PREFILL` | NONE | This event is fired after a user completes prefilling an agreement and sends it. |
+| **Event Type** | **Data** | **Description**                                                                  |
+| -------------- | -------- | -------------------------------------------------------------------------------- |
+| `ESIGN`        | NONE     | This event gets fired after a user has successfully signed an agreement.         |
+| `REJECT`       | NONE     | This event is fired after a user rejects an agreement.                           |
+| `PREFILL`      | NONE     | This event is fired after a user completes prefilling an agreement and sends it. |
 
 ### **Page Load events**
 
@@ -54,10 +54,10 @@ The following table lists the Adobe Sign supported UI events that can be embedde
          <td><strong>'PAGE_LOAD'</strong></td>
          <td>
             <ul>
-               <li>pageName: 'AUTHORING'<br></li>
+               <li>pageName: 'AUTHORING'<br/></li>
             </ul>
          </td>
-         <td>This event fires when the form-field authoring page loads for an agreement.<br></td>
+         <td>This event fires when the form-field authoring page loads for an agreement.<br/></td>
       </tr>
       <tr>
          <td>'PAGE_LOAD'</strong></td>

--- a/webhooks/webhook_events/agreement_action_completed.md
+++ b/webhooks/webhook_events/agreement_action_completed.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_ACTION\_COMPLETED
+# Payload: AGREEMENT_ACTION_COMPLETED
 
 ## Payload attributes
 
@@ -83,7 +83,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -184,7 +184,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -206,121 +206,119 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantRole":"",
-   "actionType":"",
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantRole": "",
+  "actionType": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_action_delegated.md
+++ b/webhooks/webhook_events/agreement_action_delegated.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_ACTION\_DELEGATED
+# Payload: AGREEMENT_ACTION_DELEGATED
 
 ## Payload attributes
 
@@ -83,7 +83,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -190,7 +190,7 @@
       </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if the conditional parameter <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -212,141 +212,139 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantRole":"",
-   "actionType":"",
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantRole": "",
+  "actionType": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_action_replaced_signer.md
+++ b/webhooks/webhook_events/agreement_action_replaced_signer.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_ACTION\_REPLACED\_SIGNER
+# Payload: AGREEMENT_ACTION_REPLACED_SIGNER
 
 ## Payload attributes
 
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -199,138 +199,137 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],"event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_action_requested.md
+++ b/webhooks/webhook_events/agreement_action_requested.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_ACTION\_REQUESTED
+# Payload: AGREEMENT_ACTION_REQUESTED
 
 ## Payload attributes
 
@@ -45,6 +45,7 @@
 </table>
 
 ### Inherited from Agreement:
+
 <table>
   <thead>
     <tr>
@@ -70,7 +71,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -177,7 +178,7 @@
       </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if the conditional parameter <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold. In some cases when document processing takes a lot of time, you might not get <code>documentsInfo</code> even if the conditional parameter <code>includeDocumentsInfo</code> was set to true. In such a case try calling the v6 <a href="https://secure.echosign.com/public/docs/restapi/v6#!/agreements/getAllDocuments">GET /agreements/{agreementId}/documents</a> API to get the details of the documents of an agreement.</td>
       <td>&nbsp;</td>
     </tr>
@@ -196,144 +197,142 @@
   </tbody>
 </table>
 
-
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantRole":"",
-   "actionType":"",
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantRole": "",
+  "actionType": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
+```

--- a/webhooks/webhook_events/agreement_auto_cancelled_conversion_problem.md
+++ b/webhooks/webhook_events/agreement_auto_cancelled_conversion_problem.md
@@ -1,8 +1,8 @@
-# Payload: AGREEMENT\_AUTO\_CANCELLED\_CONVERSION\_PROBLEM
+# Payload: AGREEMENT_AUTO_CANCELLED_CONVERSION_PROBLEM
 
 ## Payload attributes
 
-### Event-specific: 
+### Event-specific:
 
 <table>
   <thead>
@@ -72,7 +72,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -179,7 +179,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -201,99 +201,97 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_created.md
+++ b/webhooks/webhook_events/agreement_created.md
@@ -1,8 +1,8 @@
-# Payload: AGREEMENT\_CREATED
+# Payload: AGREEMENT_CREATED
 
 ## Payload attributes
 
-### Event-specific: 
+### Event-specific:
 
 <table>
   <thead>
@@ -72,7 +72,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -195,119 +195,117 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_documents_deleted.md
+++ b/webhooks/webhook_events/agreement_documents_deleted.md
@@ -1,8 +1,8 @@
-# Payload: AGREEMENT\_DOCUMENTS\_DELETED
+# Payload: AGREEMENT_DOCUMENTS_DELETED
 
 ## Payload attributes
 
-### Event-specific: 
+### Event-specific:
 
 <table>
   <thead>
@@ -72,7 +72,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -184,98 +184,96 @@
 
 ```json
 {
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo": {
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement": {
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs": [
-         {
-            "email":"",
-            "label":"",
-            "visiblePages": [
-               ""
-            ]
-         }
-      ],
-      "deviceInfo": {
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location": {
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId": {
-         "id":""
-      },
-      "postSignOption": {
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo": {
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo": {
-         "participantSets": [
-            {
-               "memberInfos": [
-                  {
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_email_bounced.md
+++ b/webhooks/webhook_events/agreement_email_bounced.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_EMAIL\_BOUNCED
+# Payload: AGREEMENT_EMAIL_BOUNCED
 
 ## Payload attributes
 
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -199,139 +199,137 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_email_viewed.md
+++ b/webhooks/webhook_events/agreement_email_viewed.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_EMAIL\_VIEWED
+# Payload: AGREEMENT_EMAIL_VIEWED
 
 ## Payload attributes
 
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -199,139 +199,137 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_expired.md
+++ b/webhooks/webhook_events/agreement_expired.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_EXPIRED
+# Payload: AGREEMENT_EXPIRED
 
 ## Payload attributes
 
@@ -51,7 +51,7 @@
     <tr>
       <td><code>initiatingUserEmail</code></td>
       <td>String</td>
-      <td><br></td>
+      <td><br/></td>
     </tr>
   </tbody>
 </table>
@@ -83,7 +83,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -184,7 +184,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -206,119 +206,117 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_kba_authenticated.md
+++ b/webhooks/webhook_events/agreement_kba_authenticated.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_KBA\_AUTHENTICATED
+# Payload: AGREEMENT_KBA_AUTHENTICATED
 
 ## Payload attributes
 
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -199,140 +199,137 @@
 ## Payload template
 
 ```json
-{  
-
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_modified.md
+++ b/webhooks/webhook_events/agreement_modified.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_MODIFIED
+# Payload: AGREEMENT_MODIFIED
 
 ## Payload attributes
 
@@ -72,7 +72,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -179,7 +179,7 @@
       </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -201,139 +201,137 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_offline_sync.md
+++ b/webhooks/webhook_events/agreement_offline_sync.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_OFFLINE\_SYNC
+# Payload: AGREEMENT_OFFLINE_SYNC
 
 ## Payload attributes
 
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -199,139 +199,137 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_recalled.md
+++ b/webhooks/webhook_events/agreement_recalled.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_RECALLED
+# Payload: AGREEMENT_RECALLED
 
 ## Payload attributes
 
@@ -85,7 +85,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -186,7 +186,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold. </td>
       <td>&nbsp;</td>
     </tr>
@@ -208,119 +208,117 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_rejected.md
+++ b/webhooks/webhook_events/agreement_rejected.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_REJECTED
+# Payload: AGREEMENT_REJECTED
 
 ## Payload attributes
 
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -170,7 +170,7 @@
       <td>&nbsp;</td>
     </tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -192,119 +192,117 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_shared.md
+++ b/webhooks/webhook_events/agreement_shared.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_SHARED
+# Payload: AGREEMENT_SHARED
 
 ## Payload attributes
 
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -199,139 +199,137 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_uploaded_by_sender.md
+++ b/webhooks/webhook_events/agreement_uploaded_by_sender.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_UPLOADED\_BY\_SENDER
+# Payload: AGREEMENT_UPLOADED_BY_SENDER
 
 ## Payload attributes
 
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -200,138 +200,136 @@
 
 ```json
 {
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo": {
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement": {
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs": [
-         {
-            "email":"",
-            "label":"",
-            "visiblePages": [
-               ""
-            ]
-         }
-      ],
-      "deviceInfo": {
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location": {
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId": {
-         "id":""
-      },
-      "postSignOption": {
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo": {
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo": {
-         "participantSets": [
-            {
-               "memberInfos": [
-                  {
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets": [
-            {
-               "memberInfos": [
-                  {
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo": {
-         "documents": [
-            {
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments": [
-            {
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_user_ack_agreement_modified.md
+++ b/webhooks/webhook_events/agreement_user_ack_agreement_modified.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_USER\_ACK\_AGREEMENT\_MODIFIED
+# Payload: AGREEMENT_USER_ACK_AGREEMENT_MODIFIED
 
 ## Payload attributes
 
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -199,139 +199,137 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_vaulted.md
+++ b/webhooks/webhook_events/agreement_vaulted.md
@@ -1,4 +1,4 @@
-# Payload: AGREEMENT\_VAULTED
+# Payload: AGREEMENT_VAULTED
 
 ## Payload attributes
 
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -171,7 +171,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -193,119 +193,117 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_web_identity_authenticated.md
+++ b/webhooks/webhook_events/agreement_web_identity_authenticated.md
@@ -1,8 +1,8 @@
-# Payload: AGREEMENT\_WEB\_IDENTITY\_AUTHENTICATED
+# Payload: AGREEMENT_WEB_IDENTITY_AUTHENTICATED
 
 ## Payload attributes
 
-### Event-specific: 
+### Event-specific:
 
 <table>
   <thead>
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -177,7 +177,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -200,138 +200,136 @@
 
 ```json
 {
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo": {
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement": {
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs": [
-         {
-            "email":"",
-            "label":"",
-            "visiblePages": [
-               ""
-            ]
-         }
-      ],
-      "deviceInfo": {
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location": {
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId": {
-         "id":""
-      },
-      "postSignOption": {
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo": {
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo": {
-         "participantSets": [
-            {
-               "memberInfos": [
-                  {
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ],
-         "nextParticipantSets": [
-            {
-               "memberInfos": [
-                  {
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo": {
-         "documents": [
-            {
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments": [
-            {
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ],
+      "nextParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/agreement_workflow_completed.md
+++ b/webhooks/webhook_events/agreement_workflow_completed.md
@@ -1,8 +1,8 @@
-# Payload: AGREEMENT\_WORKFLOW\_COMPLETED
+# Payload: AGREEMENT_WORKFLOW_COMPLETED
 
 ## Payload attributes
- 
-### Event-specific: 
+
+### Event-specific:
 
 <table>
   <thead>
@@ -12,7 +12,7 @@
       <th><strong>Description</strong></th>
     </tr>
   </thead>
-  <tbody>    
+  <tbody>
     <tr>
       <td><code>participantUserId</code></td>
       <td>String</td>
@@ -70,7 +70,7 @@
     <tr>
       <td><code>signatureType</code></td>
       <td>Enum</td>
-      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br></td>
+      <td>Specifies the type of signature requested on the agreement&mdash;written or e-signature.<br/></td>
       <td><code>ESIGN</code>, <code>WRITTEN</code></td>
     </tr>
     <tr>
@@ -171,7 +171,7 @@
     </tr>
     <tr>
       <td><code>documentsInfo</code></td>
-      <td>Object<br></td>
+      <td>Object<br/></td>
       <td>Returns the IDs of the documents of an agreement. Returned only if conditional parameters <code>includeDocumentsInfo</code> is set to true and payload size is less than the threshold.</td>
       <td>&nbsp;</td>
     </tr>
@@ -196,123 +196,121 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers":[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-        "payloadApplicable":"" 
-      } 
-    ],
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "eventResourceParentType":"",
-   "eventResourceParentId":"", 
-   "participantRole":"",
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"",
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "agreement":{  
-      "id":"",
-      "name":"",
-      "signatureType":"",
-      "status":"",
-      "ccs":[  
-         {  
-            "email":"",
-            "label":"",
-            "visiblePages":[  
-               ""
-            ]
-         }
-      ],
-      "deviceInfo":{  
-         "applicationDescription":"",
-         "deviceDescription":"",
-         "location":{  
-            "latitude":"",
-            "longitude":""
-         },
-         "deviceTime":""
-      },
-      "documentVisibilityEnabled":"",
-      "createdDate":"",
-      "expirationTime":"",
-      "externalId":{  
-         "id":""
-      },
-      "postSignOption":{  
-         "redirectDelay":"",
-         "redirectUrl":""
-      },
-      "firstReminderDelay":"",
-      "locale":"",
-      "message":"",
-      "reminderFrequency":"",
-      "senderEmail":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "workflowId":"",
-      "participantSetsInfo":{  
-         "participantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "status":"",
-               "id":"",
-               "name":"",
-               "privateMessage":""
-            }
-         ]
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ],
-         "supportingDocuments":[  
-            {  
-               "displayLabel":"",
-               "fieldName":"",
-               "id":"",
-               "mimeType":"",
-               "numPages":""
-            }
-         ]
-      },
-      "signedDocumentInfo":{  
-         "document":""
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "eventResourceParentType": "",
+  "eventResourceParentId": "",
+  "participantRole": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "agreement": {
+    "id": "",
+    "name": "",
+    "signatureType": "",
+    "status": "",
+    "ccs": [
+      {
+        "email": "",
+        "label": "",
+        "visiblePages": [""]
       }
-   }
+    ],
+    "deviceInfo": {
+      "applicationDescription": "",
+      "deviceDescription": "",
+      "location": {
+        "latitude": "",
+        "longitude": ""
+      },
+      "deviceTime": ""
+    },
+    "documentVisibilityEnabled": "",
+    "createdDate": "",
+    "expirationTime": "",
+    "externalId": {
+      "id": ""
+    },
+    "postSignOption": {
+      "redirectDelay": "",
+      "redirectUrl": ""
+    },
+    "firstReminderDelay": "",
+    "locale": "",
+    "message": "",
+    "reminderFrequency": "",
+    "senderEmail": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "workflowId": "",
+    "participantSetsInfo": {
+      "participantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "status": "",
+          "id": "",
+          "name": "",
+          "privateMessage": ""
+        }
+      ]
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ],
+      "supportingDocuments": [
+        {
+          "displayLabel": "",
+          "fieldName": "",
+          "id": "",
+          "mimeType": "",
+          "numPages": ""
+        }
+      ]
+    },
+    "signedDocumentInfo": {
+      "document": ""
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/widget_auto_cancelled_conversion_problem.md
+++ b/webhooks/webhook_events/widget_auto_cancelled_conversion_problem.md
@@ -1,8 +1,8 @@
-# Payload: WIDGET\_AUTO\_CANCELLED\_CONVERSION\_PROBLEM
+# Payload: WIDGET_AUTO_CANCELLED_CONVERSION_PROBLEM
 
 ## Payload attributes
 
-### Event-specific: 
+### Event-specific:
 
 <table>
   <thead>
@@ -44,7 +44,7 @@
 </table>
 
 ### Inherted from Widget:
-	
+
 <table>
   <thead>
     <tr>
@@ -112,7 +112,7 @@
     <tr>
       <td><code>locale</code></td>
       <td>String</td>
-      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br></td>
+      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br/></td>
       <td>&nbsp;</td>
     </tr>
     <tr>
@@ -151,91 +151,91 @@
 
 ```json
 {
-   "webhookId": "",
-   "webhookName":"",
-   "webhookNotificationId": "",
-   "webhookUrlInfo": {
-      "url": ""
-   },
-   "webhookScope": "",
-   "webhookNotificationApplicableUsers" :[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-      "payloadApplicable":"" 
-     } 
-   ], 
-   "event": "",
-   "subEvent": "",
-   "eventDate":"", 
-   "eventResourceType": "",
-   "participantUserId": "",
-   "participantUserEmail": "",
-   "actingUserId": "",
-   "actingUserEmail": "",
-   "actingUserIpAddress":"", 
-   "initiatingUserId": "",
-   "initiatingUserEmail": "",
-   "widget": {
-      "name": "",
-      "status": "",
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
       "id": "",
-      "authFailureInfo": {
-         "url": "",
-         "deframe": "",
-         "delay": ""
-      },
-      "ccs": [
-         {
-            "email": ""
-         }
-      ],
-      "completionInfo": {
-         "url": "",
-         "deframe": "",
-         "delay": ""
-      },
-      "creatorEmail": "",
-      "createdDate": "",
-      "locale": "",
-      "vaultingInfo": {
-         "enabled": ""
-      },
-      "participantSetsInfo": {
-         "additionalParticipantSets": [
-            {
-               "memberInfos": [
-                  {
-                     "id": "",
-                     "email": "",
-                     "company": "",
-                     "name": "",
-                     "privateMessage": "",
-                     "status": ""
-                  }
-               ],
-               "order": "",
-               "role": "",
-               "id": ""
-            }
-         ],
-         "widgetParticipantSet": {
-            "memberInfos": [
-               {
-                  "id": "",
-                  "email": "",
-                  "company": "",
-                  "name": "",
-                  "privateMessage": "",
-                  "status": ""
-               }
-            ],
-            "order": "",
-            "role": "",
-            "id": ""
-         }
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "widget": {
+    "name": "",
+    "status": "",
+    "id": "",
+    "authFailureInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "ccs": [
+      {
+        "email": ""
       }
-   }
+    ],
+    "completionInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "creatorEmail": "",
+    "createdDate": "",
+    "locale": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "participantSetsInfo": {
+      "additionalParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "id": ""
+        }
+      ],
+      "widgetParticipantSet": {
+        "memberInfos": [
+          {
+            "id": "",
+            "email": "",
+            "company": "",
+            "name": "",
+            "privateMessage": "",
+            "status": ""
+          }
+        ],
+        "order": "",
+        "role": "",
+        "id": ""
+      }
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/widget_created.md
+++ b/webhooks/webhook_events/widget_created.md
@@ -1,8 +1,8 @@
-# Payload: WIDGET\_CREATED
+# Payload: WIDGET_CREATED
 
 ## Payload attributes
 
-### Event-specific: 
+### Event-specific:
 
 <table>
   <thead>
@@ -106,7 +106,7 @@
     <tr>
       <td><code>locale</code></td>
       <td>String</td>
-      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br></td>
+      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br/></td>
       <td>&nbsp;</td>
     </tr>
     <tr>
@@ -144,103 +144,103 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers" :[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-      "payloadApplicable":"" 
-     } 
-   ], 
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"", 
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "widget":{  
-      "name":"",
-      "status":"",
-      "id":"",
-      "authFailureInfo":{  
-         "url":"",
-         "deframe":"",
-         "delay":""
-      },
-      "ccs":[  
-         {  
-            "email":""
-         }
-      ],
-      "completionInfo":{  
-         "url":"",
-         "deframe":"",
-         "delay":""
-      },
-      "creatorEmail":"",
-      "createdDate":"",
-      "locale":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "participantSetsInfo":{  
-         "additionalParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "id":""
-            }
-         ],
-         "widgetParticipantSet":{  
-            "memberInfos":[  
-               {  
-                  "id":"",
-                  "email":"",
-                  "company":"",
-                  "name":"",
-                  "privateMessage":"",
-                  "status":""
-               }
-            ],
-            "order":"",
-            "role":"",
-            "id":""
-         }
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "widget": {
+    "name": "",
+    "status": "",
+    "id": "",
+    "authFailureInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "ccs": [
+      {
+        "email": ""
       }
-   }
+    ],
+    "completionInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "creatorEmail": "",
+    "createdDate": "",
+    "locale": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "participantSetsInfo": {
+      "additionalParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "id": ""
+        }
+      ],
+      "widgetParticipantSet": {
+        "memberInfos": [
+          {
+            "id": "",
+            "email": "",
+            "company": "",
+            "name": "",
+            "privateMessage": "",
+            "status": ""
+          }
+        ],
+        "order": "",
+        "role": "",
+        "id": ""
+      }
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/widget_disabled.md
+++ b/webhooks/webhook_events/widget_disabled.md
@@ -1,8 +1,8 @@
-# Payload: WIDGET\_DISABLED
+# Payload: WIDGET_DISABLED
 
 ## Payload attributes
 
-### Event-specific: 
+### Event-specific:
 
 <table>
   <thead>
@@ -43,7 +43,7 @@
   </tbody>
 </table>
 
-### Inherited from Widget: 
+### Inherited from Widget:
 
 <table>
   <thead>
@@ -112,7 +112,7 @@
     <tr>
       <td><code>locale</code></td>
       <td>String</td>
-      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br></td>
+      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br/></td>
       <td>&nbsp;</td>
     </tr>
     <tr>
@@ -150,107 +150,107 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers" :[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-      "payloadApplicable":"" 
-     } 
-   ], 
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"", 
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "widget":{  
-      "name":"",
-      "status":"",
-      "id":"",
-      "authFailureInfo":{  
-         "url":"",
-         "deframe":"",
-         "delay":""
-      },
-      "ccs":[  
-         {  
-            "email":""
-         }
-      ],
-      "completionInfo":{  
-         "url":"",
-         "deframe":"",
-         "delay":""
-      },
-      "disabledWidgetOptions":{  
-         "message":"",
-         "redirectUrl":""
-      },
-      "creatorEmail":"",
-      "createdDate":"",
-      "locale":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "participantSetsInfo":{  
-         "additionalParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "id":""
-            }
-         ],
-         "widgetParticipantSet":{  
-            "memberInfos":[  
-               {  
-                  "id":"",
-                  "email":"",
-                  "company":"",
-                  "name":"",
-                  "privateMessage":"",
-                  "status":""
-               }
-            ],
-            "order":"",
-            "role":"",
-            "id":""
-         }
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "widget": {
+    "name": "",
+    "status": "",
+    "id": "",
+    "authFailureInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "ccs": [
+      {
+        "email": ""
       }
-   }
+    ],
+    "completionInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "disabledWidgetOptions": {
+      "message": "",
+      "redirectUrl": ""
+    },
+    "creatorEmail": "",
+    "createdDate": "",
+    "locale": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "participantSetsInfo": {
+      "additionalParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "id": ""
+        }
+      ],
+      "widgetParticipantSet": {
+        "memberInfos": [
+          {
+            "id": "",
+            "email": "",
+            "company": "",
+            "name": "",
+            "privateMessage": "",
+            "status": ""
+          }
+        ],
+        "order": "",
+        "role": "",
+        "id": ""
+      }
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/widget_enabled.md
+++ b/webhooks/webhook_events/widget_enabled.md
@@ -1,8 +1,8 @@
-# Payload: WIDGET\_ENABLED
+# Payload: WIDGET_ENABLED
 
 ## Payload attributes
 
-### Event-specific: 
+### Event-specific:
 
 <table>
   <thead>
@@ -106,7 +106,7 @@
     <tr>
       <td><code>locale</code></td>
       <td>String</td>
-      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br></td>
+      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br/></td>
       <td>&nbsp;</td>
     </tr>
     <tr>
@@ -144,103 +144,103 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers" :[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-      "payloadApplicable":"" 
-     } 
-   ], 
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"", 
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "widget":{  
-      "name":"",
-      "status":"",
-      "id":"",
-      "authFailureInfo":{  
-         "url":"",
-         "deframe":"",
-         "delay":""
-      },
-      "ccs":[  
-         {  
-            "email":""
-         }
-      ],
-      "completionInfo":{  
-         "url":"",
-         "deframe":"",
-         "delay":""
-      },
-      "creatorEmail":"",
-      "createdDate":"",
-      "locale":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "participantSetsInfo":{  
-         "additionalParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "id":""
-            }
-         ],
-         "widgetParticipantSet":{  
-            "memberInfos":[  
-               {  
-                  "id":"",
-                  "email":"",
-                  "company":"",
-                  "name":"",
-                  "privateMessage":"",
-                  "status":""
-               }
-            ],
-            "order":"",
-            "role":"",
-            "id":""
-         }
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "widget": {
+    "name": "",
+    "status": "",
+    "id": "",
+    "authFailureInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "ccs": [
+      {
+        "email": ""
       }
-   }
+    ],
+    "completionInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "creatorEmail": "",
+    "createdDate": "",
+    "locale": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "participantSetsInfo": {
+      "additionalParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "id": ""
+        }
+      ],
+      "widgetParticipantSet": {
+        "memberInfos": [
+          {
+            "id": "",
+            "email": "",
+            "company": "",
+            "name": "",
+            "privateMessage": "",
+            "status": ""
+          }
+        ],
+        "order": "",
+        "role": "",
+        "id": ""
+      }
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/widget_modified.md
+++ b/webhooks/webhook_events/widget_modified.md
@@ -1,8 +1,8 @@
-# Payload: WIDGET\_MODIFIED
+# Payload: WIDGET_MODIFIED
 
 ## Payload attributes
 
-### Event-specific: 
+### Event-specific:
 
 <table>
   <thead>
@@ -44,7 +44,7 @@
 </table>
 
 ### Inherted from Widget:
-	
+
 <table>
   <thead>
     <tr>
@@ -112,7 +112,7 @@
     <tr>
       <td><code>locale</code></td>
       <td>String</td>
-      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br></td>
+      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br/></td>
       <td>&nbsp;</td>
     </tr>
     <tr>
@@ -150,107 +150,107 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers" :[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-      "payloadApplicable":"" 
-     } 
-   ], 
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"", 
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "widget":{  
-      "name":"",
-      "status":"",
-      "id":"",
-      "authFailureInfo":{  
-         "url":"",
-         "deframe":"",
-         "delay":""
-      },
-      "ccs":[  
-         {  
-            "email":""
-         }
-      ],
-      "completionInfo":{  
-         "url":"",
-         "deframe":"",
-         "delay":""
-      },
-      "disabledWidgetOptions":{  
-         "message":"",
-         "redirectUrl":""
-      },
-      "creatorEmail":"",
-      "createdDate":"",
-      "locale":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "participantSetsInfo":{  
-         "additionalParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "id":""
-            }
-         ],
-         "widgetParticipantSet":{  
-            "memberInfos":[  
-               {  
-                  "id":"",
-                  "email":"",
-                  "company":"",
-                  "name":"",
-                  "privateMessage":"",
-                  "status":""
-               }
-            ],
-            "order":"",
-            "role":"",
-            "id":""
-         }
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "widget": {
+    "name": "",
+    "status": "",
+    "id": "",
+    "authFailureInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "ccs": [
+      {
+        "email": ""
       }
-   }
+    ],
+    "completionInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "disabledWidgetOptions": {
+      "message": "",
+      "redirectUrl": ""
+    },
+    "creatorEmail": "",
+    "createdDate": "",
+    "locale": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "participantSetsInfo": {
+      "additionalParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "id": ""
+        }
+      ],
+      "widgetParticipantSet": {
+        "memberInfos": [
+          {
+            "id": "",
+            "email": "",
+            "company": "",
+            "name": "",
+            "privateMessage": "",
+            "status": ""
+          }
+        ],
+        "order": "",
+        "role": "",
+        "id": ""
+      }
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ]
+    }
+  }
 }
 ```

--- a/webhooks/webhook_events/widget_shared.md
+++ b/webhooks/webhook_events/widget_shared.md
@@ -1,8 +1,8 @@
-# Payload: WIDGET\_SHARED
+# Payload: WIDGET_SHARED
 
 ## Payload attributes
 
-### Event-specific: 
+### Event-specific:
 
 <table>
   <thead>
@@ -44,7 +44,7 @@
 </table>
 
 ### Inherted from Widget:
-	
+
 <table>
   <thead>
     <tr>
@@ -112,7 +112,7 @@
     <tr>
       <td><code>locale</code></td>
       <td>String</td>
-      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br></td>
+      <td>Locale associated with this widget: specifies the language for the signing page and emails; for example <code>en_US</code> or <code>fr_FR</code>. If none is specified, this defaults to the language configured for the widget creator.<br/></td>
       <td>&nbsp;</td>
     </tr>
     <tr>
@@ -150,107 +150,107 @@
 ## Payload template
 
 ```json
-{  
-   "webhookId":"",
-   "webhookName":"",
-   "webhookNotificationId":"",
-   "webhookUrlInfo":{  
-      "url":""
-   },
-   "webhookScope":"",
-   "webhookNotificationApplicableUsers" :[  
-    {  
-      "id":"", 
-      "email":"", 
-      "role":"", 
-      "payloadApplicable":"" 
-     } 
-   ], 
-   "event":"",
-   "subEvent":"",
-   "eventDate":"", 
-   "eventResourceType":"",
-   "participantUserId":"",
-   "participantUserEmail":"",
-   "actingUserId":"",
-   "actingUserEmail":"",
-   "actingUserIpAddress":"", 
-   "initiatingUserId":"",
-   "initiatingUserEmail":"",
-   "widget":{  
-      "name":"",
-      "status":"",
-      "id":"",
-      "authFailureInfo":{  
-         "url":"",
-         "deframe":"",
-         "delay":""
-      },
-      "ccs":[  
-         {  
-            "email":""
-         }
-      ],
-      "completionInfo":{  
-         "url":"",
-         "deframe":"",
-         "delay":""
-      },
-      "disabledWidgetOptions":{  
-         "message":"",
-         "redirectUrl":""
-      },
-      "creatorEmail":"",
-      "createdDate":"",
-      "locale":"",
-      "vaultingInfo":{  
-         "enabled":""
-      },
-      "participantSetsInfo":{  
-         "additionalParticipantSets":[  
-            {  
-               "memberInfos":[  
-                  {  
-                     "id":"",
-                     "email":"",
-                     "company":"",
-                     "name":"",
-                     "privateMessage":"",
-                     "status":""
-                  }
-               ],
-               "order":"",
-               "role":"",
-               "id":""
-            }
-         ],
-         "widgetParticipantSet":{  
-            "memberInfos":[  
-               {  
-                  "id":"",
-                  "email":"",
-                  "company":"",
-                  "name":"",
-                  "privateMessage":"",
-                  "status":""
-               }
-            ],
-            "order":"",
-            "role":"",
-            "id":""
-         }
-      },
-      "documentsInfo":{  
-         "documents":[  
-            {  
-               "id":"",
-               "label":"",
-               "numPages":"",
-               "mimeType":"",
-               "name":""
-            }
-         ]
+{
+  "webhookId": "",
+  "webhookName": "",
+  "webhookNotificationId": "",
+  "webhookUrlInfo": {
+    "url": ""
+  },
+  "webhookScope": "",
+  "webhookNotificationApplicableUsers": [
+    {
+      "id": "",
+      "email": "",
+      "role": "",
+      "payloadApplicable": ""
+    }
+  ],
+  "event": "",
+  "subEvent": "",
+  "eventDate": "",
+  "eventResourceType": "",
+  "participantUserId": "",
+  "participantUserEmail": "",
+  "actingUserId": "",
+  "actingUserEmail": "",
+  "actingUserIpAddress": "",
+  "initiatingUserId": "",
+  "initiatingUserEmail": "",
+  "widget": {
+    "name": "",
+    "status": "",
+    "id": "",
+    "authFailureInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "ccs": [
+      {
+        "email": ""
       }
-   }
+    ],
+    "completionInfo": {
+      "url": "",
+      "deframe": "",
+      "delay": ""
+    },
+    "disabledWidgetOptions": {
+      "message": "",
+      "redirectUrl": ""
+    },
+    "creatorEmail": "",
+    "createdDate": "",
+    "locale": "",
+    "vaultingInfo": {
+      "enabled": ""
+    },
+    "participantSetsInfo": {
+      "additionalParticipantSets": [
+        {
+          "memberInfos": [
+            {
+              "id": "",
+              "email": "",
+              "company": "",
+              "name": "",
+              "privateMessage": "",
+              "status": ""
+            }
+          ],
+          "order": "",
+          "role": "",
+          "id": ""
+        }
+      ],
+      "widgetParticipantSet": {
+        "memberInfos": [
+          {
+            "id": "",
+            "email": "",
+            "company": "",
+            "name": "",
+            "privateMessage": "",
+            "status": ""
+          }
+        ],
+        "order": "",
+        "role": "",
+        "id": ""
+      }
+    },
+    "documentsInfo": {
+      "documents": [
+        {
+          "id": "",
+          "label": "",
+          "numPages": "",
+          "mimeType": "",
+          "name": ""
+        }
+      ]
+    }
+  }
 }
 ```


### PR DESCRIPTION
We will be moving to a new system to display these docs on adobe.io and the website will fail to build if there are unclosed html tags like `<br> or <hr>`. This PR fixes all instances of `<br>` to be `<br/>` in this repo.